### PR TITLE
Fix build and add app name in connection info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
       <uniqueVersion>false</uniqueVersion>
       <id>pentaho</id>
       <name>Pentaho Open Repository</name>
-      <url>http://repository.pentaho.org/artifactory/pentaho</url>
+      <url>http://nexus.pentaho.org/content/groups/omni</url>
       <layout>default</layout>
     </repository>
   </distributionManagement>
@@ -102,7 +102,7 @@
     <maven-replacer-plugin.version>1.4.0</maven-replacer-plugin.version>
     <maven-source-plugin.version>2.1.2</maven-source-plugin.version>
     <maven-surefire-plugin.version>2.17</maven-surefire-plugin.version>
-    <mondrian-data-foodmart.version>0.9-SNAPSHOT</mondrian-data-foodmart.version>
+    <mondrian-data-foodmart.version>1.0.0</mondrian-data-foodmart.version>
     <mondrian.version>4.3.0.1-130</mondrian.version>
     <mysql-connector-java.version>5.1.38</mysql-connector-java.version>
     <rt-java5.version>1.5.0_22</rt-java5.version>
@@ -249,7 +249,7 @@
       </releases>
       <id>pentaho</id>
       <name>Pentaho</name>
-      <url>http://repository.pentaho.org/artifactory/pentaho</url>
+      <url>http://nexus.pentaho.org/content/groups/omni</url>
     </repository>
   </repositories>
 
@@ -337,6 +337,7 @@
           <excludes>
             <exclude>**/*.md</exclude>
             <exclude>RELEASE_CHECKLIST.txt</exclude>
+            <exclude>VERSION.txt</exclude>
             <exclude>doc/*</exclude>
             <exclude>.travis.yml</exclude>
           </excludes>

--- a/src/org/olap4j/driver/xmla/XmlaOlap4jConnection.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jConnection.java
@@ -1168,6 +1168,10 @@ abstract class XmlaOlap4jConnection implements OlapConnection {
             + "    <Properties>\n"
             + "      <PropertyList>\n");
 
+        buf.append("        <SspropInitAppName>");
+        xmlEncode(buf, "OLAP4J");
+        buf.append("</SspropInitAppName>\n");
+
         String conProperties = makeConnectionPropertyList();
         if (conProperties != null && !("".equals(conProperties))) {
             buf.append(conProperties);

--- a/src/org/olap4j/driver/xmla/XmlaOlap4jResultSet.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jResultSet.java
@@ -1,3 +1,20 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
 package org.olap4j.driver.xmla;
 
 import org.olap4j.OlapException;

--- a/src/org/olap4j/driver/xmla/XmlaOlap4jRowSet.java
+++ b/src/org/olap4j/driver/xmla/XmlaOlap4jRowSet.java
@@ -1,3 +1,20 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
 package org.olap4j.driver.xmla;
 
 import static org.olap4j.driver.xmla.XmlaOlap4jUtil.childElements;

--- a/testsrc/org/olap4j/driver/xmla/proxy/XmlaCachedProxyTest.java
+++ b/testsrc/org/olap4j/driver/xmla/proxy/XmlaCachedProxyTest.java
@@ -41,7 +41,7 @@ public class XmlaCachedProxyTest extends TestCase {
      */
     public void testCacheConfig() throws Exception
     {
-        XmlaOlap4jCachedProxy proxy = new XmlaOlap4jHttpProxy(dummyDriver);
+        XmlaOlap4jCachedProxy proxy = new XmlaOlap4jHttpProxy(dummyDriver, null);
         Map<String, String> driverParameters = new HashMap<String, String>();
         Map<String, String> cacheProperties = new HashMap<String, String>();
 
@@ -76,7 +76,7 @@ public class XmlaCachedProxyTest extends TestCase {
      * @throws Exception If the test fails.
      */
     public void testCacheModeError() throws Exception {
-        XmlaOlap4jCachedProxy proxy = new XmlaOlap4jHttpProxy(dummyDriver);
+        XmlaOlap4jCachedProxy proxy = new XmlaOlap4jHttpProxy(dummyDriver, null);
         Map<String, String> driverParameters = new HashMap<String, String>();
         Map<String, String> cacheProperties = new HashMap<String, String>();
 
@@ -119,7 +119,7 @@ public class XmlaCachedProxyTest extends TestCase {
      */
     public void testCacheTimeoutError() throws Exception
     {
-        XmlaOlap4jCachedProxy proxy = new XmlaOlap4jHttpProxy(dummyDriver);
+        XmlaOlap4jCachedProxy proxy = new XmlaOlap4jHttpProxy(dummyDriver, null);
         Map<String, String> driverParameters = new HashMap<String, String>();
         Map<String, String> cacheProperties = new HashMap<String, String>();
 
@@ -169,7 +169,7 @@ public class XmlaCachedProxyTest extends TestCase {
      */
     public void testCacheSizeError() throws Exception
     {
-        XmlaOlap4jCachedProxy proxy = new XmlaOlap4jHttpProxy(dummyDriver);
+        XmlaOlap4jCachedProxy proxy = new XmlaOlap4jHttpProxy(dummyDriver, null);
         Map<String, String> driverParameters = new HashMap<String, String>();
         Map<String, String> cacheProperties = new HashMap<String, String>();
 
@@ -218,7 +218,7 @@ public class XmlaCachedProxyTest extends TestCase {
      */
     public void testCacheNameError() throws Exception
     {
-        XmlaOlap4jCachedProxy proxy = new XmlaOlap4jHttpProxy(dummyDriver);
+        XmlaOlap4jCachedProxy proxy = new XmlaOlap4jHttpProxy(dummyDriver, null);
         Map<String, String> driverParameters = new HashMap<String, String>();
         Map<String, String> cacheProperties = new HashMap<String, String>();
 
@@ -265,7 +265,7 @@ public class XmlaCachedProxyTest extends TestCase {
      */
     public void testCacheSharing() throws Exception
     {
-        XmlaOlap4jCachedProxy proxy = new XmlaOlap4jHttpProxy(dummyDriver);
+        XmlaOlap4jCachedProxy proxy = new XmlaOlap4jHttpProxy(dummyDriver, null);
         Map<String, String> driverParameters = new HashMap<String, String>();
         Map<String, String> cacheProperties = new HashMap<String, String>();
 
@@ -325,7 +325,7 @@ public class XmlaCachedProxyTest extends TestCase {
             // This endures that 1 - the caches are shared in a static manner
             // and that 2 - the cache is reused and it's
             // parameters are not overwritten.
-            proxy = new XmlaOlap4jHttpProxy(dummyDriver);
+            proxy = new XmlaOlap4jHttpProxy(dummyDriver, null);
             proxy.setCache(driverParameters, cacheProperties);
         } catch (Throwable e) {
             fail(


### PR DESCRIPTION
Fix the build
* Update repository URL
* Update `mondrian-data-foodmart` version from non-existent `0.9-SNAPSHOT` to `1.0.0`
* Add Apache 2.0 license headers for new classes
* Fix test compilation due to change in `XmlaOlap4jHttpProxy` constructor definition

Set the application name to `OLAP4J` to ease identification during server side profiling